### PR TITLE
Add support for Craft CSRF Protection

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -69,6 +69,9 @@
 
 {% set content %}
 <form method="post" action="" accept-charset="UTF-8">
+    
+    {{ getCsrfInput() }}
+    
     <input type="hidden" name="action" value="sitemap/saveSections">
 
     <table id="sitemap" class="sitemap data">


### PR DESCRIPTION
If CSRF is enabled in Craft settings it would unable to submit the form without `{{ getCsrfInput() }}`.
